### PR TITLE
Removed duplicate "required" in TokenAuthorization

### DIFF
--- a/payments-swagger.yaml
+++ b/payments-swagger.yaml
@@ -248,10 +248,6 @@ definitions:
             corporate hierarchy. The service will validate that the
             merchant authentication token is authorized to perform the
             operation.
-    required:
-    - currency
-    - amount
-    - token
   Capture:
     type: object
     properties:


### PR DESCRIPTION
Fixes YAML Syntax Error, Duplicated mapping key at line 255, column 3
